### PR TITLE
improved nginx-reload.sh script

### DIFF
--- a/nginx-reload.sh
+++ b/nginx-reload.sh
@@ -1,31 +1,48 @@
 #!/bin/bash
 
+
+log() {
+  date_time="$(date +%Y-%m-%d\ %H:%M:%S)"
+  if [ -z $2 ]; then
+    echo "${date_time} nginx: $1"
+  else
+    (>&2 echo "${date_time} nginx: ERROR: $1")
+  fi
+}
+
+
 {
-  echo "Starting nginx"
-  nginx "$@" && exit 1
+  log "starting"
+  nginx -g 'daemon off;' "$@" && exit 1
 } &
 
 nginx_pid=$!
 
-watches=${WATCH_PATHS:-"/etc/nginx/nginx.conf"}
+watches=${NGINX_WATCH_PATHS:-"/etc/nginx/nginx.conf"}
+config_file=${NGINX_CONFIG_FILE:-"/etc/nginx/nginx.conf"}
 
-echo "Setting up watches for ${watches[@]}"
+log "setting up watches for ${watches[@]}"
 
 {
-  echo $nginx_pid
-  inotifywait -e modify,move,create,delete --timefmt '%d/%m/%y %H:%M' -m --format '%T' \
-  ${watches[@]} | while read date time; do
-
-    echo "At ${time} on ${date}, config file update detected"
-    nginx -t
-    if [ $? -ne 0 ]; then
-      echo "ERROR: New configuration is invalid!!"
-    else
-      echo "New configuration is valid, reloading nginx"
-      nginx -s reload
+  log "pid $nginx_pid"
+  inotifywait -r -q -e modify,move,create,delete --format '%w %e %T' -m --timefmt '%H%M%S'  \
+  ${watches[@]} | while read file event tm; do
+    current=$(date +'%H%M%S')
+    delta=`expr $current - $tm`
+    log "at ${tm} config file ${file} update detected (${event})"
+    if [ $delta -lt 2 -a $delta -gt -2 ] ; then
+      sleep 2  # sleep 1 set to let file operations end
+      log "will test config  $config_file"
+      nginx -t -c $config_file
+      if [ $? -ne 0 ]; then
+        log "new configuration is invalid!!" 1
+      else
+        log "new configuration is valid, reloading"
+        nginx -s reload
+      fi
     fi
   done
-  echo "inotifywait failed, killing nginx"
+  log "inotifywait failed, killing nginx" 1
 
   kill -TERM $nginx_pid
 } &


### PR DESCRIPTION
1. Added log() function which logs events with timestamp, adds `nginx` prefix, optionally into stderr
2. Added debounce so that we would not get multiple reloads (source: https://stackoverflow.com/a/12807105/911849) 
3. Added option NGINX_CONFIG_FILE which allows you to specify custom config file to test (`-t`) by default tests /etc/nginx/nginx.conf
4. Added recursive option into inotifywait (usefull if you have couple of ssl certs mounted e.g. in /etc/nginx/ssl